### PR TITLE
update to work with latest google changes

### DIFF
--- a/ResultPicker.js
+++ b/ResultPicker.js
@@ -1,36 +1,49 @@
-document.selectedResultId=0
+// modified version of https://superuser.com/a/1235058/69589
 
-function selectResult(newId){
-    els = document.querySelectorAll("div.r h3")
-    if(newId < 0 || newId >= els.length)
-        return  //Could modify for page nav...?
-    rp = document.getElementById("result-pointer")
-    if(rp != null){
-        rp.remove()
-    }
-    document.selectedResultId=newId
-    el = els[newId]
-    lnk = el.parentElement
-    el.innerHTML = "<div id=\"result-pointer\" style=\"position:absolute;left:-15px;\">&gt;</div>" + el.innerHTML
-    lnk.focus()
+// find all the search results
+const querySelector = '.rc > div.yuRUbf';
+
+document.selectedResultId = 0;
+function selectResult(newId) {
+    els = document.querySelectorAll(querySelector)
+    if (newId < 0 || newId >= els.length) {
+        return  //Could modify for page nav...?
+    }
+    rp = document.getElementById("result-pointer");
+    if (rp != null) {
+        rp.remove();
+    }
+    document.selectedResultId = newId;
+    el = els[newId];
+    lnk = el.firstElementChild;
+    el.innerHTML = "<div id=\"result-pointer\" style=\"position:absolute;left:-15px;\">&gt;</div>" + el.innerHTML;
+    lnk.focus();
 }
-document.onkeyup=function(event){
-    if(event.keyCode==38)
-        selectResult(document.selectedResultId-1)
-    if(event.keyCode==40)
-        selectResult(document.selectedResultId+1)
-    if(event.keyCode==13){
-      var el = document.querySelectorAll("div.r h3")[document.selectedResultId]
-      var lnk = el.parentElement
-      var url = lnk.href
-      if(event.ctrlKey){
-        var win = window.open(url,"_blank")
-        win.blur()
-        window.open().close()
-      }
-      else{
-        document.location = url
-      }
-    }
+document.onkeydown = function(event) {
+    // the '/' key
+    if (event.keyCode == 191) {
+        document.getElementsByName("q")[0].focus();
+    }
+
+    // the up arrow key
+    if (event.keyCode == 38) {
+        selectResult(document.selectedResultId-1);
+    }
+
+    // the down arrrow key
+    if (event.keyCode == 40) {
+        selectResult(document.selectedResultId+1);
+    }
+    // the enter key
+    if (event.keyCode == 13) {
+      var el = document.querySelectorAll(querySelector)[document.selectedResultId];
+      var lnk = el.querySelector("a");
+      var url = lnk.href;
+      if (event.metaKey) {
+        var win = window.open(url,"_blank");
+      } else {
+        document.location = url;
+      }
+    }
 }
-selectResult(0)
+selectResult(0);


### PR DESCRIPTION
This change is what fixes it for latest google changes: `.rc > div.yuRUbf`

Since we use the query selector in more than one place I extracted it to a constant.

The support for the '/' key (keyCode191) let's me press / and get the focus back to the search text so I can change my google search.

I also changed `event.ctrlKey` to `event.metaKey`. I'm on a mac and CMD+Enter makes more sense than CTRL+Enter since CMD+click opens links in another tab.