### PR TITLE
Fix the ">" not showing up

### DIFF
--- a/ResultPicker.js
+++ b/ResultPicker.js
@@ -1,49 +1,53 @@
-// modified version of https://superuser.com/a/1235058/69589
+// from https://github.com/RobinH-J/SearchingShortcuts
 
-// find all the search results
-const querySelector = 'div.yuRUbf';
-
+// selector to find all Google search results. Simplified Google html:
+//   <div class="yuRUbf">
+//     <a href="The real url is here">
+//       <br>
+//       <h3>The big text we see in Google Search results</h3>
+//     </a>
+//   </div>
+// And sometimes we get pseudo-results (like Ads) that don't contain the h3: exclude them.
+const querySelector = 'div.yuRUbf h3';
 document.selectedResultId = 0;
+
 function selectResult(newId) {
-    els = document.querySelectorAll(querySelector)
-    if (newId < 0 || newId >= els.length) {
-        return  //Could modify for page nav...?
-    }
-    rp = document.getElementById("result-pointer");
-    if (rp != null) {
-        rp.remove();
-    }
-    document.selectedResultId = newId;
-    el = els[newId];
-    lnk = el.querySelector("a");
-    lnk.focus();
-    el.innerHTML = "<div id=\"result-pointer\" style=\"position:absolute;left:-15px;\">&gt;</div>" + el.innerHTML;
-}
-document.onkeydown = function(event) {
-    // the '/' key
-    if (event.keyCode == 191) {
-        document.getElementsByName("q")[0].focus();
+    let linkTextArray = Array.from(document.querySelectorAll(querySelector)).filter(node =>
+        // filter out the "People also ask" section of results (which don't initially display)
+        !node.closest('.ULSxyf')
+    );
+    if (newId < 0 || newId >= linkTextArray.length) {
+        return  // future idea: modify for next/prev page
     }
 
+    document.selectedResultId = newId;
+    let linkText = linkTextArray[newId];
+    let link = linkText.parentElement;
+    link.focus();
+}
+
+document.onkeydown = function(event) {
     // the up arrow key
-    if (event.keyCode == 38) {
-        selectResult(document.selectedResultId-1);
+    if (event.key === 'ArrowUp') {
+        selectResult(document.selectedResultId - 1);
     }
 
     // the down arrrow key
-    if (event.keyCode == 40) {
-        selectResult(document.selectedResultId+1);
+    if (event.key === 'ArrowDown') {
+        selectResult(document.selectedResultId + 1);
     }
     // the enter key
-    if (event.keyCode == 13) {
-      var el = document.querySelectorAll(querySelector)[document.selectedResultId];
-      var lnk = el.querySelector("a");
-      var url = lnk.href;
+    if (event.key === 'Enter') {
+      let linkText = document.querySelectorAll(querySelector)[document.selectedResultId];
+      let link = linkText.parentElement;
+      let url = link.href;
       if (event.metaKey) {
-        var win = window.open(url,"_blank");
+        window.open(url, '_blank');
       } else {
         document.location = url;
       }
     }
 }
+
+// when the plugin activates, select the first result
 selectResult(0);

--- a/ResultPicker.js
+++ b/ResultPicker.js
@@ -25,8 +25,13 @@ function selectResult(newId) {
 
 function getSearchResultsAsArray() {
   return Array.from(document.querySelectorAll(querySelector)).filter(node =>
-    // filter out the "People also ask" section of results (which don't initially display)
-    !node.closest('.ULSxyf')
+    // Filter out "People also ask" section.
+    // Links in that section aren't initially shown, so skip them
+    // Queries to test with:
+    //   "who is the president" displays the 'People also ask' section
+    //   "npm create package" displays a 'featured snippet' + link above the main results (we want that link to get selected)
+    //   "what is an apple" displays a link, then the 'People also ask' section
+    !node.closest('.Wt5Tfe')
   );
 }
 
@@ -36,7 +41,7 @@ document.onkeydown = function(event) {
         selectResult(document.selectedResultId - 1);
     }
 
-    // the down arrrow key
+    // the down arrow key
     if (event.key === 'ArrowDown') {
         selectResult(document.selectedResultId + 1);
     }

--- a/ResultPicker.js
+++ b/ResultPicker.js
@@ -12,10 +12,7 @@ const querySelector = 'div.yuRUbf h3';
 document.selectedResultId = 0;
 
 function selectResult(newId) {
-    let linkTextArray = Array.from(document.querySelectorAll(querySelector)).filter(node =>
-        // filter out the "People also ask" section of results (which don't initially display)
-        !node.closest('.ULSxyf')
-    );
+    let linkTextArray = getSearchResultsAsArray();
     if (newId < 0 || newId >= linkTextArray.length) {
         return  // future idea: modify for next/prev page
     }
@@ -24,6 +21,13 @@ function selectResult(newId) {
     let linkText = linkTextArray[newId];
     let link = linkText.parentElement;
     link.focus();
+}
+
+function getSearchResultsAsArray() {
+  return Array.from(document.querySelectorAll(querySelector)).filter(node =>
+    // filter out the "People also ask" section of results (which don't initially display)
+    !node.closest('.ULSxyf')
+  );
 }
 
 document.onkeydown = function(event) {
@@ -38,7 +42,7 @@ document.onkeydown = function(event) {
     }
     // the enter key
     if (event.key === 'Enter') {
-      let linkText = document.querySelectorAll(querySelector)[document.selectedResultId];
+      let linkText = getSearchResultsAsArray()[document.selectedResultId];
       let link = linkText.parentElement;
       let url = link.href;
       if (event.metaKey) {


### PR DESCRIPTION
The ">" symbol used to indicate the currently selected results, but it stopped working. I could get it to show up if I set the position to "left:0px" instead of "left:-15px", but then the ">" symbol appeared on top of other text. I went a totally different route and let focus() do the job, ensuring the page scrolls down to the selected element, and hopefully insulates us from future changes since we're not styling anything now.

Also, explicitly filter out Ads (which weren't a problem before) and the "People also ask" section, which means the keyboard shortcut jumps from one link to another, without having to press the Down Arrow multiple times to skip that section.